### PR TITLE
Remove retry at upper level

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,7 @@
   <properties>
     <revision>0-SNAPSHOT</revision>
     <exec.logLevel>debug</exec.logLevel>
+    <surefire.logLevel>off</surefire.logLevel>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -386,6 +387,11 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <version>${plugin.surefire.version}</version>
+        <configuration>
+          <systemPropertyVariables>
+            <org.slf4j.simpleLogger.defaultLogLevel>${surefire.logLevel}</org.slf4j.simpleLogger.defaultLogLevel>
+          </systemPropertyVariables>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/src/main/java/com/github/princesslana/eriscasper/BotTokenWrapper.java
+++ b/src/main/java/com/github/princesslana/eriscasper/BotTokenWrapper.java
@@ -6,9 +6,4 @@ import org.immutables.value.Value;
 
 @Value.Immutable
 @Wrapped
-public abstract class BotTokenWrapper implements Wrapper<String> {
-  @Override
-  public String toString() {
-    return "[BOT TOKEN]";
-  }
-}
+public interface BotTokenWrapper extends Wrapper<String> {}

--- a/src/main/java/com/github/princesslana/eriscasper/ErisCasper.java
+++ b/src/main/java/com/github/princesslana/eriscasper/ErisCasper.java
@@ -53,7 +53,6 @@ public class ErisCasper {
 
     bot.apply(new BotContext(events, routes, rm))
         .doOnError(t -> LOG.warn("Exception thrown by Bot", t))
-        .retry()
         .blockingAwait();
   }
 


### PR DESCRIPTION
The removes the retry from ErisCasper#run

Adds tests to ensure that the Gateway will not allow an exception to bubble up and crash a bot because of bad tests.