### PR TITLE
Handle websocket closing

### DIFF
--- a/src/main/java/com/github/princesslana/eriscasper/gateway/Gateway.java
+++ b/src/main/java/com/github/princesslana/eriscasper/gateway/Gateway.java
@@ -90,17 +90,14 @@ public class Gateway {
   @SuppressWarnings("unchecked")
   public Observable<Event> connect(String url, BotToken token, Optional<Shard> shard) {
     Observable<RxWebSocketEvent> websocketEvents =
-        ws.connect(String.format("%s?v=%s&encoding=%s", url, VERSION, ENCODING));
-    websocketEvents
-        .ofType(RxWebSocketEvent.Closing.class)
-        .doOnNext(
-            e -> {
-              if (e.getCode() == 4004) {
-                e.getWebSocket().close(1002, "Invalid token.");
-                throw new ErisCasperFatalException("Failed to authenticate with discord servers.");
-              }
-            })
-        .share();
+        ws.connect(String.format("%s?v=%s&encoding=%s", url, VERSION, ENCODING))
+            .flatMap(
+                e ->
+                    e instanceof RxWebSocketEvent.Closing || e instanceof RxWebSocketEvent.Closed
+                        ? Observable.error(
+                            new ErisCasperFatalException("Websocket closed unexpectedly: " + e))
+                        : Observable.just(e));
+
     Observable<Payload> ps =
         websocketEvents
             .ofType(RxWebSocketEvent.StringMessage.class)

--- a/src/main/java/com/github/princesslana/eriscasper/rx/websocket/RxWebSocket.java
+++ b/src/main/java/com/github/princesslana/eriscasper/rx/websocket/RxWebSocket.java
@@ -31,7 +31,6 @@ public class RxWebSocket {
 
               ws = http.newWebSocket(rq, new Listener(em));
             })
-        .takeUntil(e -> e instanceof RxWebSocketEvent.Closed)
         .doOnNext(e -> LOG.trace("Received: {}.", e))
         .doOnError(e -> LOG.warn("Error: {}.", e));
   }


### PR DESCRIPTION
To be reviewed after #176.

This adds a test and ensures we throw an exception on any websocket closing or closed event. At the moment we have no way to recover from such an event and should not do nothing.

This is an improvement, but not yet optimal (e.g., on a Closing, Invalid Shard payload the exception is thrown and logged, we no longer send/receive any data, but the program does not stop).

Due to the behavior seen, some logic around stopping that is not working was also removed.